### PR TITLE
images/mtda-image.inc : Add ifupdown package

### DIFF
--- a/meta-isar/recipes-core/images/mtda-image.inc
+++ b/meta-isar/recipes-core/images/mtda-image.inc
@@ -25,6 +25,7 @@ IMAGE_INSTALL += "                       \
 "
 
 IMAGE_PREINSTALL += "                    \
+    ifupdown                             \
     iproute2                             \
     isc-dhcp-client                      \
     mjpg-streamer                        \


### PR DESCRIPTION
Requires the package for setting static ip
for assist board and will provide the
network/interface file.

Signed-off-by: sarath P T <Sarath_PT@mentor.com>